### PR TITLE
Bump log4j-api from 2.14.1 to 2.15.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ configurations {
 dependencies {
     implementation 'org.cip4.lib.jdf:JDFLibJ:2.1.7.+'
     implementation 'org.cip4.lib.jdf:JDFLibJ-JSON:+'
-    implementation 'org.apache.logging.log4j:log4j-api:2.14.1'
+    implementation 'org.apache.logging.log4j:log4j-api:2.15.0'
     implementation 'org.apache.logging.log4j:log4j-core:2.14.1'
     implementation 'commons-configuration:commons-configuration:1.10'
     implementation 'commons-collections:commons-collections:3.2.2'


### PR DESCRIPTION
Bumps log4j-api from 2.14.1 to 2.15.0.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-api
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>