### PR TITLE
Stop writing to program directory

### DIFF
--- a/src/main/java/org/cip4/tools/jdfeditor/JDFFrame.java
+++ b/src/main/java/org/cip4/tools/jdfeditor/JDFFrame.java
@@ -120,6 +120,7 @@ import javax.swing.undo.CannotUndoException;
 import javax.swing.undo.UndoManager;
 import javax.swing.undo.UndoableEditSupport;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.cip4.jdflib.core.ElementName;
@@ -140,6 +141,7 @@ import org.cip4.jdflib.jmf.JDFMessage.EnumFamily;
 import org.cip4.jdflib.node.JDFNode;
 import org.cip4.jdflib.util.EnumUtil;
 import org.cip4.jdflib.util.StringUtil;
+import org.cip4.jdflib.util.file.UserDir;
 import org.cip4.tools.jdfeditor.controller.MainController;
 import org.cip4.tools.jdfeditor.model.enumeration.SettingKey;
 import org.cip4.tools.jdfeditor.service.DocumentService;
@@ -159,7 +161,7 @@ public class JDFFrame extends JFrame implements ActionListener, DropTargetListen
 {
 	private static final long serialVersionUID = 1L;
 	private static final String DEFAULT_TITLE = "CIP4 JDFEditor";
-	private static final String UNTITLED = "Untitled";
+	private static final String UNTITLED = FilenameUtils.concat(new UserDir("JDFEditor").getToolPath(),"Untitled");
 
 	private static final Log LOGGER = LogFactory.getLog(JDFFrame.class);
 

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration>
     <Properties>
-        <Property name="filename">JDFEditor.log</Property>
+        <Property name="filename">${sys:user.home}\CIP4Tools\JDFEditor\logs\JDFEditor.log</Property>
     </Properties>
     <Appenders>
         <Console name="STDOUT" target="SYSTEM_OUT">


### PR DESCRIPTION
We used to write to some files (JDFEditor.log and Untitled.*) relative to the JDFEditor binary (on Windows C:\Program Files\CIP4 JDFEditor\). With the new installer, we have proper permissions on this directory and these write accesses are rightfully denied.
With this patch, we are moving the files into the already existing tools' directory (on Windows "C:\User\<user>\CIP4Tools\JDFEditor")

Issues: EDITOR-82, EDITOR-83