### PR TITLE
Run tests using the custom runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,9 @@ dependencies {
 
 runtime {
     modules = [
-            'jdk.xml.dom']
+            'jdk.xml.dom',
+            'jdk.unsupported'
+    ]
     additive = true
     jpackage {
         imageOptions = [
@@ -87,4 +89,9 @@ runtime {
         imageOptions += ["--icon", icon]
         appVersion = project.version == "development" ? "1.0.0" : project.version
     }
+}
+
+test {
+    dependsOn(jre)
+    executable = jre.getJreDir().dir("bin").file("java").getAsFile().getAbsolutePath()
 }


### PR DESCRIPTION
In order to reduce the risk of shipping the JDFEditor with a broken custom runtime, we can run our test suite with exactly this custom runtime (JRE).

Issues: EDITOR-83